### PR TITLE
Fix LLD databases path

### DIFF
--- a/src/LLD/keychain.cpp
+++ b/src/LLD/keychain.cpp
@@ -15,7 +15,7 @@ namespace LLD
 		MUTEX_LOCK(REGISTRY_MUTEX);
 		
 		/** Create the New Keychain Database. **/
-		KeyDatabase* SectorKeys = new KeyDatabase(GetDefaultDataDir().string() + "/keychain/", strBaseName);
+		KeyDatabase* SectorKeys = new KeyDatabase(GetDataDir().string() + "/keychain/", strBaseName);
 		SectorKeys->Initialize();
 		
 		/** Log the new Keychain into the Memeory Map. **/

--- a/src/LLD/sector.h
+++ b/src/LLD/sector.h
@@ -72,7 +72,7 @@ namespace LLD
 		SectorDatabase(std::string strName, std::string strKeychain, const char* pszMode="r+")
 		{
 			strKeychainRegistry = strKeychain;
-			strBaseLocation = GetDefaultDataDir().string() + "/datachain/"; 
+			strBaseLocation = GetDataDir().string() + "/datachain/"; 
 			strBaseName = strName;
 			
 			/** Read only flag when instantiating new database. **/


### PR DESCRIPTION
- keychain and datachain should be kept in the same data directory specified by the "-datadir" parameter together with all the other files.