### PR TITLE
use 512

### DIFF
--- a/src/LLU/util.h
+++ b/src/LLU/util.h
@@ -658,7 +658,7 @@ uint512 SerializeHash(const T& obj, int nType=SER_GETHASH, int nVersion=PROTOCOL
     CDataStream ss(nType, nVersion);
     ss.reserve(10000);
     ss << obj;
-    return LLH::SK256(ss.begin(), ss.end());
+    return LLH::SK512(ss.begin(), ss.end());
 }
 
 


### PR DESCRIPTION
Think this should be 512 based on type returned and code that existed before recent changes.
I know you said this is all a work in progress but didn't want to forget to point this out.