### PR TITLE
Build error due to C++11 support not being enabled by default on some…

### DIFF
--- a/makefile.unix
+++ b/makefile.unix
@@ -82,7 +82,7 @@ LIBS+= \
 
 
 DEBUGFLAGS=-g
-CXXFLAGS=-O2
+CXXFLAGS=-O2 -std=c++11
 
 #add build support for the LLD vs Berklee DB
 ifdef USE_LLD

--- a/nexus-qt.pro
+++ b/nexus-qt.pro
@@ -114,7 +114,7 @@ contains(BITCOIN_NEED_QT_PLUGINS, 1) {
     # do not enable this on windows, as it will result in a non-working executable!
 }
 
-QMAKE_CXXFLAGS += -D_FORTIFY_SOURCE=2 -fpermissive
+QMAKE_CXXFLAGS += -D_FORTIFY_SOURCE=2 -fpermissive -std=c++11
 
 QMAKE_CXXFLAGS_WARN_ON = -Wall -Wextra -Wformat -Wformat-security -Wno-invalid-offsetof -Wno-sign-compare -Wno-unused-parameter
 !macx {


### PR DESCRIPTION
Build error due to C++11 support not being enabled by default on some versions of g++