### PR TITLE
fix Nexusoft/Nexus#51, overflow in R_X86_64_PC32 relocation on Ubuntu 17.10

### DIFF
--- a/nexus-qt.pro
+++ b/nexus-qt.pro
@@ -57,11 +57,6 @@ contains(RELEASE, 1) {
     windows:QMAKE_LFLAGS += -Wl,--dynamicbase -Wl,--nxcompat
     windows:QMAKE_LFLAGS += -Wl,--large-address-aware -static
     windows:QMAKE_LFLAGS += -static-libgcc -static-libstdc++
-
-    !windows:!macx {
-        # Linux: static link
-        LIBS += -Wl,-Bstatic
-    }
 }
 
 # use: qmake "USE_QRCODE=1"


### PR DESCRIPTION
Fix #51, nexus-qt wallet crash during startup on Ubuntu 17.10