### PR TITLE
make the getblock RPC command to also return the hash used in PoS/PoW validation

### DIFF
--- a/src/core/block.cpp
+++ b/src/core/block.cpp
@@ -1613,7 +1613,7 @@ namespace Core
     }
 
 
-    bool CBlock::TrustKey(uint576& cKey)
+    bool CBlock::TrustKey(uint576& cKey) const
     {
         /* Extract the Key from the Script Signature. */
         vector<std::vector<unsigned char> > vSolutions;
@@ -1635,7 +1635,7 @@ namespace Core
     }
 
 
-    bool CBlock::TrustKey(std::vector<unsigned char>& vchTrustKey)
+    bool CBlock::TrustKey(std::vector<unsigned char>& vchTrustKey) const
     {
         /* Extract the Key from the Script Signature. */
         vector<std::vector<unsigned char> > vSolutions;
@@ -1657,7 +1657,7 @@ namespace Core
     }
 
     /* New proof hash for all channels (version > 5) */
-    uint1024 CBlock::StakeHash()
+    uint1024 CBlock::StakeHash() const
     {
         /* Get the trust key. */
         uint576 cKey;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -1398,7 +1398,7 @@ namespace Core
 
 
         /* The proof of stake hash. */
-        uint1024 StakeHash();
+        uint1024 StakeHash() const;
 
 
         /* The block age for version 5 blocks. */
@@ -1414,11 +1414,11 @@ namespace Core
 
 
         /* Get the trust key from script. */
-        bool TrustKey(uint576& cKey);
+        bool TrustKey(uint576& cKey) const;
 
 
         /* Get the trust key from script. */
-        bool TrustKey(std::vector<unsigned char>& vchTrustKey);
+        bool TrustKey(std::vector<unsigned char>& vchTrustKey) const;
 
 
         /* Check the proof of stake claims. */

--- a/src/net/rpcserver.cpp
+++ b/src/net/rpcserver.cpp
@@ -127,6 +127,11 @@ namespace Net
     {
         Object result;
         result.push_back(Pair("hash", block.GetHash().GetHex()));
+        // the hash that was relevant for Proof of Stake or Proof of Work (depending on block version)
+        result.push_back(Pair("proofhash",
+                                  block.nVersion < 5   ? block.GetHash().GetHex() :
+                                ((block.nChannel == 0) ? block.StakeHash().GetHex() : block.ProofHash().GetHex())
+                             ));
         result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
         result.push_back(Pair("height", (int)blockindex->nHeight));
         result.push_back(Pair("channel", (int)block.nChannel));


### PR DESCRIPTION
without this feature, block explorers will not be able to inspect the hashes that were used to validate PoW/PoS.

The new JSON key returned by getblock is called "proofhash" and it cointains
- the block hash for V4 and lesser blocks
- the stake hash for >= V5 PoS (stake) blocks
- the proof hash for >= V5 PoW blocks (prime and hashing channels)
